### PR TITLE
fix: Fix incorrect token error message

### DIFF
--- a/lnkshrt_cli/utils.py
+++ b/lnkshrt_cli/utils.py
@@ -24,13 +24,15 @@ def _send_request(
     if base_url is None:
         base_url = INSTANCE_URL
     if headers:
-        token = headers.get("Authorization", "").removeprefix("Bearer ")
-        if not token:
-            print(
-                "Authentication token is missing. "
-                "Please log in using 'lnkshrt login' to generate a token."
-            )
-            raise typer.Abort()
+        auth_header = headers.get("Authorization")
+        if auth_header:
+            token = auth_header.removeprefix("Bearer ")
+            if not token:
+                print(
+                    "Authentication token is missing. "
+                    "Please log in using 'lnkshrt login' to generate a token."
+                )
+                raise typer.Abort()
     try:
         with httpx.Client() as client:
             response = client.request(


### PR DESCRIPTION
Previously, an error message saying token is missing would be printed for any request with headers if the token is absent in headers. The fix ensures that the error message will be displayed only if the authrization header is included and token is missing.